### PR TITLE
rough first pass edit feature, click/keyboard toggle edit, persists until reload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,13 @@ class App extends Component<{}, IAppState> {
         cols: columns,
         next: null,
         prev: 0,
-        transactions: transactions.slice(2),
+        transactions: transactions.slice(2, 5),
+      },
+      {
+        cols: columns,
+        next: null,
+        prev: 0,
+        transactions: transactions.slice(5, 9),
       },
     ];
 
@@ -119,7 +125,7 @@ class App extends Component<{}, IAppState> {
       },
     ];
 
-    const defs: ITransaction = {
+    const transactionDefaults: ITransaction = {
       amount: 0,
       bucket: '',
       created_at: '',
@@ -135,10 +141,10 @@ class App extends Component<{}, IAppState> {
     };
 
     /**
-     * [TODO]: this nested looping is no good
+     * [TODO]: this nested looping for patching defaults is no good
      */
     const transactions = result.map((before: ITransaction) => {
-      const after = Object.assign({}, defs);
+      const after = Object.assign({}, transactionDefaults);
       for (const prop in before) {
         if (before[prop] != null) {
           after[prop] = before[prop];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,8 @@ class App extends Component<{}, IAppState> {
       ],
       transactions: [],
     };
+
+    this.transactionsChanged = this.transactionsChanged.bind(this);
   }
 
   public render() {
@@ -99,13 +101,16 @@ class App extends Component<{}, IAppState> {
               const next = (i < tables.length - 1) ? (i + 1) : null;
               const prev = (i > 0) ? (i - 1) : null;
 
-              return <CustomTable
-                cols={table.cols}
-                key={`table-${i}`}
-                next={next}
-                prev={prev}
-                transactions={table.transactions}
-              ></CustomTable>;
+              return (
+                <CustomTable
+                  cols={table.cols}
+                  key={`table-${i}`}
+                  onChange={this.transactionsChanged}
+                  next={next}
+                  prev={prev}
+                  transactions={table.transactions}
+                ></CustomTable>
+              );
             })
           }
         </Paper>
@@ -155,6 +160,15 @@ class App extends Component<{}, IAppState> {
 
     this.setState({
       transactions,
+    });
+  }
+
+  /**
+   * Handle transactions changes.
+   */
+  private transactionsChanged(transactionsChanged: ITransaction[]) {
+    this.setState({
+      transactions: transactionsChanged,
     });
   }
 }

--- a/src/CustomForm.tsx
+++ b/src/CustomForm.tsx
@@ -32,17 +32,17 @@ class CustomForm extends Component<{}, ICustomFormState> {
         <CustomInput
           label="name"
           onChange={this.handleNameChange}
-          input={this.state.name}
+          inputValue={this.state.name}
         ></CustomInput>
         <CustomInput
           label="description"
           onChange={this.handleDescriptionChange}
-          input={this.state.description}
+          inputValue={this.state.description}
         ></CustomInput>
         <CustomInput
           label="amount"
           onChange={this.handleAmountChange}
-          input={this.state.amount}
+          inputValue={this.state.amount}
         ></CustomInput>
         <Button
           onSubmit={this.handleSubmit}

--- a/src/CustomInput.tsx
+++ b/src/CustomInput.tsx
@@ -7,22 +7,15 @@ import React, { Component } from 'react';
  * CustomInput props.
  */
 interface ICustomInputProps {
-  input: any;
+  inputValue: any;
   label: string;
   onChange: any;
 }
 
 /**
- * CustomInput state.
+ * Custom input component.
  */
-interface ICustomInputState {
-  input: string;
-}
-
-/**
- * Custom input componenet.
- */
-class CustomInput extends Component<ICustomInputProps, ICustomInputState> {
+class CustomInput extends Component<ICustomInputProps, {}> {
   constructor(props: any) {
     super(props);
   }
@@ -32,12 +25,15 @@ class CustomInput extends Component<ICustomInputProps, ICustomInputState> {
 
     return (
       <InputLabel>
-        <span>
-          {label}
-        </span>
+        {
+          !(label === '') &&
+          <span>
+            {label}
+          </span>
+        }
         <Input
           onChange={this.props.onChange}
-          value={this.props.input}
+          value={this.props.inputValue}
         ></Input>
       </InputLabel>
     );

--- a/src/CustomInput.tsx
+++ b/src/CustomInput.tsx
@@ -7,9 +7,9 @@ import React, { Component } from 'react';
  * CustomInput props.
  */
 interface ICustomInputProps {
+  input: any;
   label: string;
   onChange: any;
-  input: any;
 }
 
 /**
@@ -19,6 +19,9 @@ interface ICustomInputState {
   input: string;
 }
 
+/**
+ * Custom input componenet.
+ */
 class CustomInput extends Component<ICustomInputProps, ICustomInputState> {
   constructor(props: any) {
     super(props);
@@ -29,7 +32,9 @@ class CustomInput extends Component<ICustomInputProps, ICustomInputState> {
 
     return (
       <InputLabel>
-        {label}:
+        <span>
+          {label}
+        </span>
         <Input
           onChange={this.props.onChange}
           value={this.props.input}

--- a/src/CustomTable.tsx
+++ b/src/CustomTable.tsx
@@ -14,6 +14,7 @@ import CustomTableHead from './CustomTableHead';
  */
 interface ICustomTableProps {
   cols: IColumn[];
+  onChange: any;
   next: number | null;
   prev: number | null;
   transactions: ITransaction[];
@@ -24,9 +25,15 @@ interface ICustomTableProps {
  */
 class CustomTable extends Component<ICustomTableProps, {}> {
 
+  constructor(props: ICustomTableProps) {
+    super(props);
+
+    // this.transactionChanges = this.transactionChanges.bind(this);
+  }
+
   public render() {
-    const transactions: ITransaction[] = this.props.transactions;
     const cols: IColumn[] = this.props.cols;
+    const transactions: ITransaction[] = this.props.transactions;
 
     return (
       <Paper elevation={4}>
@@ -39,12 +46,23 @@ class CustomTable extends Component<ICustomTableProps, {}> {
           }
           <CustomTableBody
             cols={cols}
+            onChange={this.props.onChange}
             transactions={transactions}
           ></CustomTableBody>
         </Table>
       </Paper>
     );
   }
+
+  /**
+   * asdf
+   */
+  // private transactionChanges(t: ITransaction) {
+  //   const id = t.id;
+  //   const newT: ITransaction;
+
+  //   this.props.transactionsChanged();
+  // }
 
 }
 

--- a/src/CustomTableBody.tsx
+++ b/src/CustomTableBody.tsx
@@ -14,6 +14,7 @@ import CustomTableRow from './CustomTableRow';
  */
 interface ICustomTableBodyProps {
   cols: IColumn[];
+  onChange: any;
   transactions: ITransaction[];
 }
 
@@ -24,6 +25,7 @@ class CustomTableBody extends Component<ICustomTableBodyProps, {}> {
 
   public render() {
     const cols: IColumn[] = this.props.cols;
+    const handleChanges: any = this.props.onChange;
     const transactions: ITransaction[] = this.props.transactions;
 
     return (
@@ -33,6 +35,7 @@ class CustomTableBody extends Component<ICustomTableBodyProps, {}> {
             return (
               <CustomTableRow
                 cols={cols}
+                onChange={handleChanges}
                 key={`tr-${i}`}
                 row={row}
               ></CustomTableRow>

--- a/src/CustomTableCell.tsx
+++ b/src/CustomTableCell.tsx
@@ -11,8 +11,9 @@ import CustomInput from './CustomInput';
  * Custom table cell props.
  */
 interface ICustomTableCellProps {
-  // active: boolean;
+  active: boolean;
   col: any;
+  onClick: any;
   value: any;
 }
 
@@ -20,7 +21,6 @@ interface ICustomTableCellProps {
  * Custom table cell state.
  */
 interface ICustomTableCellState {
-  active: boolean;
 }
 
 /**
@@ -31,16 +31,11 @@ class CustomTableCell extends Component<ICustomTableCellProps, ICustomTableCellS
   constructor(props: ICustomTableCellProps) {
     super(props);
 
-    this.state = {
-      active: false,
-    };
-
     this.handleChanges = this.handleChanges.bind(this);
-    this.toggleInputActive = this.toggleInputActive.bind(this);
   }
 
   public render() {
-    const active = this.state.active;
+    const active = this.props.active;
     /**
      * [TODO] use `col` later for decisions about disabling, editing, validating
      */
@@ -57,7 +52,7 @@ class CustomTableCell extends Component<ICustomTableCellProps, ICustomTableCellS
 
     return (
       <TableCell
-        onClick={this.toggleInputActive}
+        onClick={this.props.onClick}
       >
         {inner}
       </TableCell>
@@ -70,15 +65,6 @@ class CustomTableCell extends Component<ICustomTableCellProps, ICustomTableCellS
   private handleChanges(changes: any) {
     // tslint:disable-next-line no-console
     console.log('changes stub', changes);
-  }
-
-  /**
-   * Toggle edit cell.
-   */
-  private toggleInputActive() {
-    this.setState({
-      active: !this.state.active,
-    });
   }
 
 }

--- a/src/CustomTableCell.tsx
+++ b/src/CustomTableCell.tsx
@@ -12,10 +12,10 @@ import CustomInput from './CustomInput';
  */
 interface ICustomTableCellProps {
   active: boolean;
+  cellValue: any;
   col: any;
   onChange: any;
   onClick: any;
-  cellValue: any;
 }
 
 /**

--- a/src/CustomTableCell.tsx
+++ b/src/CustomTableCell.tsx
@@ -5,31 +5,80 @@ import {
   TableCell,
 } from '@material-ui/core';
 
+import CustomInput from './CustomInput';
+
 /**
  * Custom table cell props.
  */
 interface ICustomTableCellProps {
+  // active: boolean;
   col: any;
   value: any;
 }
 
 /**
+ * Custom table cell state.
+ */
+interface ICustomTableCellState {
+  active: boolean;
+}
+
+/**
  * Custom table cell component.
  */
-class CustomTableCell extends Component<ICustomTableCellProps, {}> {
+class CustomTableCell extends Component<ICustomTableCellProps, ICustomTableCellState> {
+
+  constructor(props: ICustomTableCellProps) {
+    super(props);
+
+    this.state = {
+      active: false,
+    };
+
+    this.handleChanges = this.handleChanges.bind(this);
+    this.toggleInputActive = this.toggleInputActive.bind(this);
+  }
 
   public render() {
-    const val = this.props.value;
+    const active = this.state.active;
     /**
      * [TODO] use `col` later for decisions about disabling, editing, validating
      */
     const col = this.props.col;
+    const val = this.props.value;
+
+    const inner = active ?
+      <CustomInput
+        input={val}
+        label={''}
+        onChange={this.handleChanges}
+      ></CustomInput> :
+      val;
 
     return (
-      <TableCell>
-        {val}
+      <TableCell
+        onClick={this.toggleInputActive}
+      >
+        {inner}
       </TableCell>
     );
+  }
+
+  /**
+   * Handle input changes.
+   */
+  private handleChanges(changes: any) {
+    // tslint:disable-next-line no-console
+    console.log('changes stub', changes);
+  }
+
+  /**
+   * Toggle edit cell.
+   */
+  private toggleInputActive() {
+    this.setState({
+      active: !this.state.active,
+    });
   }
 
 }

--- a/src/CustomTableCell.tsx
+++ b/src/CustomTableCell.tsx
@@ -13,25 +13,18 @@ import CustomInput from './CustomInput';
 interface ICustomTableCellProps {
   active: boolean;
   col: any;
+  onChange: any;
   onClick: any;
-  value: any;
-}
-
-/**
- * Custom table cell state.
- */
-interface ICustomTableCellState {
+  cellValue: any;
 }
 
 /**
  * Custom table cell component.
  */
-class CustomTableCell extends Component<ICustomTableCellProps, ICustomTableCellState> {
+class CustomTableCell extends Component<ICustomTableCellProps, {}> {
 
   constructor(props: ICustomTableCellProps) {
     super(props);
-
-    this.handleChanges = this.handleChanges.bind(this);
   }
 
   public render() {
@@ -39,16 +32,16 @@ class CustomTableCell extends Component<ICustomTableCellProps, ICustomTableCellS
     /**
      * [TODO] use `col` later for decisions about disabling, editing, validating
      */
-    const col = this.props.col;
-    const val = this.props.value;
+    // const col = this.props.col;
+    const cellValue = this.props.cellValue;
 
     const inner = active ?
       <CustomInput
-        input={val}
+        inputValue={cellValue}
         label={''}
-        onChange={this.handleChanges}
+        onChange={this.props.onChange}
       ></CustomInput> :
-      val;
+      cellValue;
 
     return (
       <TableCell
@@ -57,14 +50,6 @@ class CustomTableCell extends Component<ICustomTableCellProps, ICustomTableCellS
         {inner}
       </TableCell>
     );
-  }
-
-  /**
-   * Handle input changes.
-   */
-  private handleChanges(changes: any) {
-    // tslint:disable-next-line no-console
-    console.log('changes stub', changes);
   }
 
 }

--- a/src/CustomTableRow.tsx
+++ b/src/CustomTableRow.tsx
@@ -16,9 +16,26 @@ interface ICustomTableRowProps {
 }
 
 /**
+ * Custom table row state.
+ */
+interface ICustomTableRowState {
+  active: boolean;
+}
+
+/**
  * Custom table row component.
  */
-class CustomTableRow extends Component<ICustomTableRowProps, {}> {
+class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowState> {
+
+  constructor(props: ICustomTableRowProps) {
+    super(props);
+
+    this.state = {
+      active: false,
+    };
+
+    this.toggleRowActive = this.toggleRowActive.bind(this);
+  }
 
   public render() {
     const cols: IColumn[] = this.props.cols;
@@ -30,8 +47,10 @@ class CustomTableRow extends Component<ICustomTableRowProps, {}> {
           cols.map((col: IColumn, i: number) => {
             return (
               <CustomTableCell
+                active={this.state.active}
                 col={col}
                 key={`td-${i}`}
+                onClick={this.toggleRowActive}
                 value={row[col.name]}
               ></CustomTableCell>
             );
@@ -39,6 +58,15 @@ class CustomTableRow extends Component<ICustomTableRowProps, {}> {
         }
       </TableRow>
     );
+  }
+
+  /**
+   * Enter edit row cells.
+   */
+  private toggleRowActive() {
+    this.setState({
+      active: true,
+    });
   }
 
 }

--- a/src/CustomTableRow.tsx
+++ b/src/CustomTableRow.tsx
@@ -21,6 +21,7 @@ interface ICustomTableRowProps {
  */
 interface ICustomTableRowState {
   active: boolean;
+  rowData: ITransaction;
 }
 
 /**
@@ -33,9 +34,9 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
 
     this.state = {
       active: false,
+      rowData: this.props.row,
     };
 
-    this.handleChanges = this.handleChanges.bind(this);
     this.toggleRowActive = this.toggleRowActive.bind(this);
   }
 
@@ -48,14 +49,16 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
       <TableRow>
         {
           cols.map((col: IColumn, i: number) => {
+            // logic for passing onChange a change handler that knows what it's updating?
+            const handler = this.makeInputHandler(col.name);
             return (
               <CustomTableCell
                 active={active}
-                col={col}
-                onChange={this.handleChanges}
-                key={`td-${i}`}
-                onClick={this.toggleRowActive}
                 cellValue={row[col.name]}
+                col={col}
+                key={`td-${i}`}
+                onChange={handler}
+                onClick={this.toggleRowActive}
               ></CustomTableCell>
             );
           })
@@ -74,12 +77,30 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
   }
 
   /**
-   * asdf
+   * Row input handler factory.
+   * @param {string} rowProp Column name prop passed to custom table cell.
+   * @returns {any} Input change handler function for individual cell in row.
    */
-  private handleChanges(event: any) {
-    // tslint:disable-next-line no-console
-    console.log('event', event.target.value);
+  private makeInputHandler(rowProp: string) {
+    const column = rowProp;
+
+    return (event: any) => {
+      const row = this.state.rowData;
+      row[rowProp] = event.target.value;
+
+      this.setState({
+        rowData: row,
+      });
+    };
   }
+
+  /**
+   * [TODO] handler for input return key submission of row
+   */
+
+  /**
+   * [TODO] handler for input esc key for cancel edit row
+   */
 
 }
 

--- a/src/CustomTableRow.tsx
+++ b/src/CustomTableRow.tsx
@@ -49,8 +49,10 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
       <TableRow>
         {
           cols.map((col: IColumn, i: number) => {
-            // logic for passing onChange a change handler that knows what it's updating?
-            const handler = this.makeInputHandler(col.name);
+            /**
+             * Per-cell input handler from factory.
+             */
+            const handler = this.inputHandlerFactory(col.name);
             return (
               <CustomTableCell
                 active={active}
@@ -81,7 +83,7 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
    * @param {string} rowProp Column name prop passed to custom table cell.
    * @returns {any} Input change handler function for individual cell in row.
    */
-  private makeInputHandler(rowProp: string) {
+  private inputHandlerFactory(rowProp: string) {
     const column = rowProp;
 
     return (event: any) => {
@@ -95,12 +97,29 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
   }
 
   /**
-   * [TODO] handler for input return key submission of row
+   * Save current row state.
    */
+  private saveRowEdits() {
+    this.disableRow();
+    // emit row state?
+  }
 
   /**
-   * [TODO] handler for input esc key for cancel edit row
+   * Discard current row state.
    */
+  private cancelRowEdits() {
+    this.disableRow();
+    // grab original "default" row prop, reset state
+  }
+
+  /**
+   * Make row inputs inactive for editing.
+   */
+  private disableRow() {
+    this.setState({
+      active: false,
+    });
+  }
 
 }
 

--- a/src/CustomTableRow.tsx
+++ b/src/CustomTableRow.tsx
@@ -12,6 +12,7 @@ import CustomTableCell from './CustomTableCell';
  */
 interface ICustomTableRowProps {
   cols: IColumn[];
+  onChange: any;
   row: ITransaction;
 }
 
@@ -34,10 +35,12 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
       active: false,
     };
 
+    this.handleChanges = this.handleChanges.bind(this);
     this.toggleRowActive = this.toggleRowActive.bind(this);
   }
 
   public render() {
+    const active: boolean = this.state.active;
     const cols: IColumn[] = this.props.cols;
     const row: ITransaction = this.props.row;
 
@@ -47,11 +50,12 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
           cols.map((col: IColumn, i: number) => {
             return (
               <CustomTableCell
-                active={this.state.active}
+                active={active}
                 col={col}
+                onChange={this.handleChanges}
                 key={`td-${i}`}
                 onClick={this.toggleRowActive}
-                value={row[col.name]}
+                cellValue={row[col.name]}
               ></CustomTableCell>
             );
           })
@@ -67,6 +71,14 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
     this.setState({
       active: true,
     });
+  }
+
+  /**
+   * asdf
+   */
+  private handleChanges(event: any) {
+    // tslint:disable-next-line no-console
+    console.log('event', event.target.value);
   }
 
 }


### PR DESCRIPTION
+ custom table cell active state lifted to custom table row
+ custom input state lifted to custom table row
+ custom table row factory for custom input change handlers
+ prefer generic `onChange` component prop as name convention more often than not
+ `return` key "saves" all active rows to custom table row state
+ `esc` key discards all active rows, re-populates with prop values from parent