### PR TITLE
refactor tables, columns -- mostly style

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import './App.scss';
  * Table.
  */
 interface ITable {
-  cols: IColumn[];
+  columns: IColumn[];
   transactions: ITransaction[];
 }
 
@@ -67,23 +67,22 @@ class App extends Component<{}, IAppState> {
     const tables: ITable[] = transactions.length > 5
       ? [
         {
-          cols: columns,
+          columns,
           transactions: transactions.slice(0, 2),
         },
         {
-          cols: columns,
+          columns,
           transactions: transactions.slice(2, 5),
         },
         {
-          cols: columns,
+          columns,
           transactions: transactions.slice(5),
         },
       ]
       : [
         {
+          columns,
           transactions,
-          // tslint:disable-next-line object-literal-sort-keys
-          cols: columns,
         },
       ];
 
@@ -99,7 +98,7 @@ class App extends Component<{}, IAppState> {
 
               return (
                 <CustomTable
-                  cols={table.cols}
+                  columns={table.columns}
                   key={`table-${i}`}
                   onChange={this.transactionUpdates}
                   transactions={table.transactions}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,10 @@ import CustomTable from './CustomTable';
 import './App.scss';
 
 /**
- * Table, linked list probably.
+ * Table.
  */
 interface ITable {
   cols: IColumn[];
-  next: number | null;
-  prev: number | null;
   transactions: ITransaction[];
 }
 
@@ -66,24 +64,18 @@ class App extends Component<{}, IAppState> {
     /**
      * [TODO] represent tables in state? should persist across sessions?
      */
-    const tables: any[] = transactions.length > 5
+    const tables: ITable[] = transactions.length > 5
       ? [
         {
           cols: columns,
-          next: null,
-          prev: null,
           transactions: transactions.slice(0, 2),
         },
         {
           cols: columns,
-          next: null,
-          prev: null,
           transactions: transactions.slice(2, 5),
         },
         {
           cols: columns,
-          next: null,
-          prev: null,
           transactions: transactions.slice(5),
         },
       ]
@@ -92,8 +84,6 @@ class App extends Component<{}, IAppState> {
           transactions,
           // tslint:disable-next-line object-literal-sort-keys
           cols: columns,
-          next: null,
-          prev: null,
         },
       ];
 
@@ -106,16 +96,12 @@ class App extends Component<{}, IAppState> {
             tables &&
             tables.length > 0 &&
             tables.map((table: ITable, i: number) => {
-              const next = (i < tables.length - 1) ? (i + 1) : null;
-              const prev = (i > 0) ? (i - 1) : null;
 
               return (
                 <CustomTable
                   cols={table.cols}
                   key={`table-${i}`}
                   onChange={this.transactionUpdates}
-                  next={next}
-                  prev={prev}
                   transactions={table.transactions}
                 ></CustomTable>
               );

--- a/src/CustomTable.tsx
+++ b/src/CustomTable.tsx
@@ -15,8 +15,6 @@ import CustomTableHead from './CustomTableHead';
 interface ICustomTableProps {
   cols: IColumn[];
   onChange: any;
-  next: number | null;
-  prev: number | null;
   transactions: ITransaction[];
 }
 
@@ -38,12 +36,9 @@ class CustomTable extends Component<ICustomTableProps, {}> {
     return (
       <Paper elevation={4}>
         <Table>
-          {
-            this.props.prev == null &&
-            <CustomTableHead
-              cols={cols}
-            ></CustomTableHead>
-          }
+          <CustomTableHead
+            cols={cols}
+          ></CustomTableHead>
           <CustomTableBody
             cols={cols}
             onChange={this.props.onChange}

--- a/src/CustomTable.tsx
+++ b/src/CustomTable.tsx
@@ -13,7 +13,7 @@ import CustomTableHead from './CustomTableHead';
  * Custom table props.
  */
 interface ICustomTableProps {
-  cols: IColumn[];
+  columns: IColumn[];
   onChange: any;
   transactions: ITransaction[];
 }
@@ -30,17 +30,17 @@ class CustomTable extends Component<ICustomTableProps, {}> {
   }
 
   public render() {
-    const cols: IColumn[] = this.props.cols;
+    const cols: IColumn[] = this.props.columns;
     const transactions: ITransaction[] = this.props.transactions;
 
     return (
       <Paper elevation={4}>
         <Table>
           <CustomTableHead
-            cols={cols}
+            columns={cols}
           ></CustomTableHead>
           <CustomTableBody
-            cols={cols}
+            columns={cols}
             onChange={this.props.onChange}
             transactions={transactions}
           ></CustomTableBody>

--- a/src/CustomTableBody.tsx
+++ b/src/CustomTableBody.tsx
@@ -13,7 +13,7 @@ import CustomTableRow from './CustomTableRow';
  * Custom table body props.
  */
 interface ICustomTableBodyProps {
-  cols: IColumn[];
+  columns: IColumn[];
   onChange: any;
   transactions: ITransaction[];
 }
@@ -46,7 +46,7 @@ class CustomTableBody extends Component<ICustomTableBodyProps, ICustomTableBodyS
   }
 
   public render() {
-    const cols: IColumn[] = this.props.cols;
+    const cols: IColumn[] = this.props.columns;
     const handleChanges: any = this.props.onChange;
     const transactions: ITransaction[] = this.props.transactions;
 
@@ -66,7 +66,7 @@ class CustomTableBody extends Component<ICustomTableBodyProps, ICustomTableBodyS
 
             return (
               <CustomTableRow
-                cols={cols}
+                columns={cols}
                 focused={focused}
                 key={rowKey}
                 onChange={handleChanges}

--- a/src/CustomTableCell.tsx
+++ b/src/CustomTableCell.tsx
@@ -13,7 +13,7 @@ import CustomInput from './CustomInput';
 interface ICustomTableCellProps {
   active: boolean;
   cellValue: any;
-  col: any;
+  column: any;
   onChange: any;
   onClick: any;
   onFocus: any;

--- a/src/CustomTableHead.tsx
+++ b/src/CustomTableHead.tsx
@@ -11,7 +11,7 @@ import {
  * Custom table head props.
  */
 interface ICustomTableHeadProps {
-  cols: IColumn[];
+  columns: IColumn[];
 }
 
 /**
@@ -20,16 +20,16 @@ interface ICustomTableHeadProps {
 class CustomTableHead extends Component<ICustomTableHeadProps, {}> {
 
   public render() {
-    const cols: IColumn[] = this.props.cols;
+    const cols: IColumn[] = this.props.columns;
 
     return (
       <TableHead>
         <TableRow>
           {
-            cols.map((col: IColumn, j: number) => {
+            cols.map((column: IColumn, j: number) => {
               return (
                 <TableCell key={`th-${j}`}>
-                  {col.name}
+                  {column.name}
                 </TableCell>
               );
             })

--- a/src/CustomTableRow.tsx
+++ b/src/CustomTableRow.tsx
@@ -19,7 +19,7 @@ const KEY_ESCAPE = 27;
  * Custom table row props.
  */
 interface ICustomTableRowProps {
-  cols: IColumn[];
+  columns: IColumn[];
   focused: boolean;
   onChange: any;
   onFocus: any;
@@ -53,7 +53,7 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
 
   public render() {
     const active: boolean = this.state.active;
-    const cols: IColumn[] = this.props.cols;
+    const cols: IColumn[] = this.props.columns;
     const row: ITransaction = this.state.rowData;
 
     return (
@@ -72,7 +72,7 @@ class CustomTableRow extends Component<ICustomTableRowProps, ICustomTableRowStat
               <CustomTableCell
                 active={active}
                 cellValue={row[col.name]}
-                col={col}
+                column={col}
                 key={`td-${i}`}
                 onChange={handler}
                 onClick={this.toggleRowActive}


### PR DESCRIPTION
+ don't know why I ever thought it would make sense for tables to eventually implement linked list behavior but yeah never mind that
+ `cols` is obviously `columns` but the readability/clarity of just writing `columns` out, especially as component prop names, isn't worth sacrificing for 3 characters; didn't rename `cols` everywhere but tried to be consistent about using only for temporary render assignment